### PR TITLE
Update especificaciones.html

### DIFF
--- a/especificaciones.html
+++ b/especificaciones.html
@@ -60,7 +60,7 @@
             <td></td>
         </tr>
         <tr>
-            <td>El usuario selecciona una región y/o escribe un nombre de ciudad</td>
+            <td>El usuario selecciona una región y/o escribe un nombre de provincia</td>
             <td></td>
         </tr>
         <tr>


### PR DESCRIPTION
Según el resto de la especificación, El Provinciano es un buscador de info de provincias. Entiendo que el `input` sirve para que el usuario pueda poner un **nombre de provincia** y que en los resultados de las regiones se filtren por las provincias que tengan ese nombre.

Esto trajo un poco de confusión en alumnos y profes. Capas podemos cambiarlo para aclarar :)